### PR TITLE
Make sure to preserve ICC when encoding.

### DIFF
--- a/cWebpGUI/cWebpGUI.cs
+++ b/cWebpGUI/cWebpGUI.cs
@@ -52,7 +52,7 @@ namespace cWebpGUI
 
         private string BuildOptions()
         {
-            string options = "";
+            string options = "-metadata icc";    // Make sure to preserve/copy ICC color profiles as they are important, without them final images WILL look wrong.
 
             if (chkLossless.Checked)
                 options += " -lossless";

--- a/cWebpGUI/cWebpGUI.cs
+++ b/cWebpGUI/cWebpGUI.cs
@@ -52,7 +52,7 @@ namespace cWebpGUI
 
         private string BuildOptions()
         {
-            string options = "-metadata icc";    // Make sure to preserve/copy ICC color profiles as they are important, without them final images WILL look wrong.
+            string options = " -metadata icc";    // Make sure to preserve/copy ICC color profiles as they are important, without them final images WILL look wrong.
 
             if (chkLossless.Checked)
                 options += " -lossless";


### PR DESCRIPTION
cWebP by default does not copy over or preserve ICC color profiles when creating an image which is a very **very** **VERY** bad thing to do as it **will** result in WebP files having the wrong colors if the original input files contain ICC profiles.